### PR TITLE
Ability to stake CVX on deposit

### DIFF
--- a/src/interfaces/afeth/IVotiumStrategy.sol
+++ b/src/interfaces/afeth/IVotiumStrategy.sol
@@ -10,6 +10,7 @@ interface IVotiumStrategy {
     error StaleAction();
     error WithdrawalStillLocked();
     error UnexpectedLockedCvxError();
+    error UnexpectedCvxRewardsPoolError();
     error UnauthorizedTarget();
     error NonRewardCvxSpent();
     error Shutdown();

--- a/src/interfaces/curve-convex/ICvxRewardsPool.sol
+++ b/src/interfaces/curve-convex/ICvxRewardsPool.sol
@@ -8,5 +8,6 @@ interface ICvxRewardsPool {
     function earned(address account) external view returns (uint256);
 
     function stake(uint256 amount) external;
+    function withdraw(uint256 amount, bool claim) external;
     function withdrawAll(bool claim) external;
 }

--- a/src/interfaces/curve-convex/ICvxRewardsPool.sol
+++ b/src/interfaces/curve-convex/ICvxRewardsPool.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+ICvxRewardsPool constant CVX_REWARDS_POOL = ICvxRewardsPool(address(0xCF50b810E57Ac33B91dCF525C6ddd9881B139332));
+
+interface ICvxRewardsPool { 
+    function balanceOf(address account) external view returns (uint256);
+    function earned(address account) external view returns (uint256);
+
+    function stake(uint256 amount) external;
+    function withdrawAll(bool claim) external;
+}


### PR DESCRIPTION
Scope:

- upon deposit, CVX is either staked or left in the contract depending on how close the current timestamp is to the next epoch
- within 24 hours before the next epoch, anybody can unstake CVX and lock it
- staked CVX is unstaked if there isn't enough unlocked CVX to fulfill withdrawals
- relocking was removed from  `requestWithdraw` and `withdrawLocked` functions

Further improvement suggestions:
- do not call `_processExpiredLocks` on deposit
- add a check for expired locks, rather than calling `_processExpiredLocks`
- leave deposited CVX in the contract and stake it periodically based on accumulated value and proximity to the epoch
